### PR TITLE
Use listForRepo instead of getForRepo

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = app => {
     app.on('pull_request.opened', receive);
     async function receive(context) {
     // Get all issues for repo with user as creator
-        const response = await context.github.issues.getForRepo(context.repo({
+        const response = await context.github.issues.listForRepo(context.repo({
             state: 'all',
             creator: context.payload.pull_request.user.login
         }));

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 const expect = require('expect');
 const {Application} = require('probot');
+const {GitHubAPI} = require('probot/lib/github');
 const succeedEvent = require('./events/succeedEvent');
 const failEvent = require('./events/failEvent');
 const succIssueRes = require('./events/succIssueRes');
@@ -13,62 +14,37 @@ describe('new-pr-welcome', () => {
     beforeEach(() => {
         app = new Application();
         plugin(app);
-
-        github = {
-            repos: {
-                getContents: expect.createSpy().andReturn(Promise.resolve({
-                    data: {
-                        content: Buffer.from(`newPRWelcomeComment: >\n  Hello World!`).toString('base64')
-                    }
-                }))
-            },
-            issues: {
-                getForRepo: expect.createSpy().andReturn(Promise.resolve(
-                    succIssueRes
-                )),
-                createComment: expect.createSpy()
-            }
-        };
-
+        github = new GitHubAPI();
         app.auth = () => Promise.resolve(github);
     });
 
+    function makeResponse(msg) {
+        return Promise.resolve({data: {content: Buffer.from(msg).toString('base64')}});
+    }
+
     describe('new-pr-welcome', () => {
         it('posts a comment because it is a user\'s first PR', async () => {
+            expect.spyOn(github.repos, 'getContents').andReturn(makeResponse(`newPRWelcomeComment: >\n  Hello World!`));
+            expect.spyOn(github.issues, 'listForRepo').andReturn(Promise.resolve(succIssueRes));
+            expect.spyOn(github.issues, 'createComment');
+
             await app.receive(succeedEvent);
 
-            expect(github.issues.getForRepo).toHaveBeenCalledWith({
-                owner: 'hiimbex',
-                repo: 'testing-things',
-                state: 'all',
-                creator: 'hiimbex-testing'
-            });
-
-            expect(github.repos.getContents).toHaveBeenCalledWith({
-                owner: 'hiimbex',
-                repo: 'testing-things',
-                path: '.github/config.yml'
-            });
-
+            expect(github.issues.listForRepo).toHaveBeenCalled();
+            expect(github.repos.getContents).toHaveBeenCalled();
             expect(github.issues.createComment).toHaveBeenCalled();
         });
     });
 
     describe('new-pr-welcome fail', () => {
-        beforeEach(() => {
-            github.issues.getForRepo = expect.createSpy().andReturn(Promise.resolve(failIssueRes));
-        });
-
         it('does not post a comment because it is not the user\'s first PR', async () => {
+            expect.spyOn(github.repos, 'getContents').andReturn(makeResponse(`newPRWelcomeComment: >\n  Hello World!`));
+            expect.spyOn(github.issues, 'listForRepo').andReturn(Promise.resolve(failIssueRes));
+            expect.spyOn(github.issues, 'createComment');
+
             await app.receive(failEvent);
 
-            expect(github.issues.getForRepo).toHaveBeenCalledWith({
-                owner: 'hiimbex',
-                repo: 'testing-things',
-                state: 'all',
-                creator: 'hiimbex'
-            });
-
+            expect(github.issues.listForRepo).toHaveBeenCalled();
             expect(github.repos.getContents).toNotHaveBeenCalled();
             expect(github.issues.createComment).toNotHaveBeenCalled();
         });


### PR DESCRIPTION
The GitHub client Probot uses changed `getForRepo` to `listForRepo`. Our tests mocked the GitHub client completely, so we missed that change. Updates the call, and modifies the tests to mock the real client; `expect.spyOn` will fail if it names something that's not already a function.